### PR TITLE
Increase secondary download button contrast on desktop

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -77,8 +77,8 @@
     .btn svg{width:16px;height:16px}
     .btn-primary{background:var(--text);color:#050505;border-color:rgba(255,255,255,.2);box-shadow:0 12px 30px rgba(255,255,255,.08);text-shadow:none}
     .btn-primary:hover{opacity:.9}
-    .btn-secondary{background:rgba(255,255,255,.06);color:var(--text-secondary);border:1px solid rgba(255,255,255,.12)}
-    .btn-secondary:hover{border-color:var(--border-hover);color:var(--text)}
+    .btn-secondary{background:rgba(255,255,255,.1);color:var(--text);border:1px solid rgba(255,255,255,.25)}
+    .btn-secondary:hover{border-color:rgba(255,255,255,.4);background:rgba(255,255,255,.15)}
 
     /* ─── BADGES ─── */
     .badges-left,.badges-right{position:fixed;z-index:3;display:flex;flex-direction:column;gap:12px;top:50%;transform:translateY(-50%)}

--- a/website/zh-TW/index.html
+++ b/website/zh-TW/index.html
@@ -70,8 +70,8 @@
     .btn svg{width:16px;height:16px}
     .btn-primary{background:var(--text);color:#050505;border-color:rgba(255,255,255,.2);box-shadow:0 12px 30px rgba(255,255,255,.08);text-shadow:none}
     .btn-primary:hover{opacity:.9}
-    .btn-secondary{background:rgba(255,255,255,.06);color:var(--text-secondary);border:1px solid rgba(255,255,255,.12)}
-    .btn-secondary:hover{border-color:var(--border-hover);color:var(--text)}
+    .btn-secondary{background:rgba(255,255,255,.1);color:var(--text);border:1px solid rgba(255,255,255,.25)}
+    .btn-secondary:hover{border-color:rgba(255,255,255,.4);background:rgba(255,255,255,.15)}
 
     /* ─── BADGES ─── */
     .badges-left,.badges-right{position:fixed;z-index:3;display:flex;flex-direction:column;gap:12px;top:50%;transform:translateY(-50%)}


### PR DESCRIPTION
Bumped background opacity from .06 to .1, border from .12 to .25, and use full white text color so the macOS button no longer blends into the dark background on desktop/laptop screens.
