### PR TITLE
fix: load persisted tasks from disk on startup

### DIFF
--- a/crates/codirigent-ui/src/workspace/gpui.rs
+++ b/crates/codirigent-ui/src/workspace/gpui.rs
@@ -718,6 +718,17 @@ impl WorkspaceView {
             event_bus as Arc<dyn codirigent_core::EventBus>,
         )));
 
+        // Load persisted tasks from disk so the task board survives restarts.
+        // load() is async but performs only synchronous file I/O, so a
+        // single-threaded tokio runtime is sufficient here.
+        if let Ok(rt) = tokio::runtime::Runtime::new() {
+            if let Ok(mut mgr) = task_manager.lock() {
+                if let Err(e) = rt.block_on(mgr.load()) {
+                    warn!("Failed to load persisted tasks: {}", e);
+                }
+            }
+        }
+
         (storage, task_manager)
     }
 


### PR DESCRIPTION
## Summary

- Calls `TaskManager::load()` after initialization in `init_task_manager()` so that existing `task-*.json` files are read from disk when the app starts
- Tasks created via the task board UI now survive app restarts
- Uses the same `tokio::runtime::Runtime::new().block_on()` pattern already established in `integration.rs`

Fixes #32

## Details

`init_task_manager()` in `gpui.rs` creates a new `TaskManager` but never calls `load()` to read existing task files from the data directory (`~/Library/Application Support/Codirigent/.codirigent/tasks/`). This means the task board starts empty on every launch despite task JSON files being intact on disk.

The fix adds 11 lines after the `TaskManager` is created:

```rust
if let Ok(rt) = tokio::runtime::Runtime::new() {
    if let Ok(mut mgr) = task_manager.lock() {
        if let Err(e) = rt.block_on(mgr.load()) {
            warn!("Failed to load persisted tasks: {}", e);
        }
    }
}
```

`load()` is marked `async` but performs only synchronous file I/O (`std::fs`), so the single-threaded tokio runtime is lightweight and sufficient. All error paths are handled gracefully — a load failure logs a warning but doesn't prevent the app from starting.

## Test plan

- [ ] Create tasks via the task board UI
- [ ] Quit and reopen Codirigent
- [ ] Verify tasks appear on the board after restart
- [ ] Verify tasks retain correct status, priority, and metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)