### PR TITLE
fix: include Nerd Font family fonts in Windows terminal font detection

### DIFF
--- a/crates/codirigent-ui/src/workspace/editor_detection.rs
+++ b/crates/codirigent-ui/src/workspace/editor_detection.rs
@@ -184,6 +184,23 @@ pub(super) fn detect_monospace_fonts(text_system: &gpui::TextSystem) -> Vec<Stri
     // Avoid probing missing fonts with resolve_font() on Windows because GPUI
     // logs each miss at error level.
     let preferred = [
+        // Nerd Font variants (checked first since users install them intentionally)
+        "JetBrainsMono Nerd Font",
+        "FiraCode Nerd Font",
+        "CaskaydiaCove Nerd Font",
+        "CaskaydiaMono Nerd Font",
+        "Hack Nerd Font",
+        "MesloLGS Nerd Font",
+        "MesloLGM Nerd Font",
+        "SourceCodePro Nerd Font",
+        "Inconsolata Nerd Font",
+        "DejaVuSansM Nerd Font",
+        "DroidSansM Nerd Font",
+        "RobotoMono Nerd Font",
+        "UbuntuMono Nerd Font",
+        "Mononoki Nerd Font",
+        "ProFontWindows Nerd Font",
+        // Standard monospace fonts
         "Cascadia Code",
         "Consolas",
         "JetBrains Mono",
@@ -200,7 +217,18 @@ pub(super) fn detect_monospace_fonts(text_system: &gpui::TextSystem) -> Vec<Stri
         .map(|name| (*name).to_string())
         .collect();
 
-    // Fallback heuristic when none of the preferred faces are available.
+    // Catch any remaining Nerd Font that wasn't in the preferred list.
+    let nerd_fonts: Vec<String> = all_names
+        .iter()
+        .filter(|name| {
+            let lower = name.to_lowercase();
+            lower.contains("nerd font") && !is_symbol_font(name)
+        })
+        .cloned()
+        .collect();
+    monospace.extend(nerd_fonts);
+
+    // Fallback heuristic when none of the above are available.
     if monospace.is_empty() {
         monospace = all_names
             .iter()


### PR DESCRIPTION
## Summary

 - Added 15 common Nerd Font variants to the Windows preferred monospace font list so they appear as
  selectable terminal fonts
 - Added a catch-all filter that detects any system font containing "Nerd Font" in its name, covering variants
   not in the explicit list
 - Prioritized Nerd Font entries before standard fonts, since users who install them likely intend to use them
   as their terminal font
## Why

Shell prompts like Starship rely on Nerd Font glyphs (custom icons for git branches, language symbols,
directory markers, etc.) to render their symbols. Without a Nerd Font selected as the terminal font, these
glyphs appear as empty boxes or question marks. On Windows, the terminal font picker only offered fonts from
a hardcoded preferred list, which excluded all Nerd Font variants — even when they were installed on the
system.

## Test plan

- Verify on Windows: install a Nerd Font (e.g., JetBrainsMono Nerd Font), launch Codirigent, confirm it
appears in the terminal font picker
- Verify on Windows: select a Nerd Font, open a session with Starship prompt, confirm glyphs render correctly
- Verify on Windows: without any Nerd Fonts installed, confirm the existing font list is unchanged and the
default (Consolas) still works