### PR TITLE
fix: load persisted tasks on startup

### DIFF
--- a/crates/codirigent-core/src/task_manager.rs
+++ b/crates/codirigent-core/src/task_manager.rs
@@ -177,6 +177,18 @@ impl TaskManager {
     ///
     /// Returns an error if loading from storage fails.
     pub async fn load(&mut self) -> Result<()> {
+        self.load_from_storage()
+    }
+
+    /// Load state from storage without requiring an async runtime.
+    ///
+    /// The storage service is synchronous, so UI startup paths can restore
+    /// persisted tasks before rendering the task board.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if loading from storage fails.
+    pub fn load_from_storage(&mut self) -> Result<()> {
         let task_ids = self.storage.list_task_ids()?;
 
         for id in task_ids {

--- a/crates/codirigent-ui/src/integration.rs
+++ b/crates/codirigent-ui/src/integration.rs
@@ -156,11 +156,15 @@ impl CodirigentIntegration {
             config.compaction.clone(),
         )));
 
-        let task_manager = Arc::new(Mutex::new(TaskManager::new(
+        let mut restored_task_manager = TaskManager::new(
             TaskManagerConfig::default(),
             storage.clone(),
             event_bus.clone(),
-        )));
+        );
+        restored_task_manager
+            .load_from_storage()
+            .context("Failed to load persisted tasks")?;
+        let task_manager = Arc::new(Mutex::new(restored_task_manager));
 
         let integration = Self {
             session_manager,

--- a/crates/codirigent-ui/src/workspace/gpui.rs
+++ b/crates/codirigent-ui/src/workspace/gpui.rs
@@ -712,11 +712,15 @@ impl WorkspaceView {
             FileStorageService::new(&temp_dir).expect("Failed to create fallback storage")
         })) as Arc<dyn codirigent_core::StorageService>;
 
-        let task_manager = Arc::new(Mutex::new(TaskManager::new(
+        let mut task_manager = TaskManager::new(
             TaskManagerConfig::default(),
             storage.clone(),
             event_bus as Arc<dyn codirigent_core::EventBus>,
-        )));
+        );
+        if let Err(e) = task_manager.load_from_storage() {
+            warn!(error = %e, "Failed to load persisted tasks");
+        }
+        let task_manager = Arc::new(Mutex::new(task_manager));
 
         (storage, task_manager)
     }


### PR DESCRIPTION
## Summary
- Add a synchronous `TaskManager::load_from_storage()` wrapper around the existing persisted-task restore logic.
- Load persisted tasks when the integration and GPUI workspace services are initialized, so the task board survives app restarts.
- Preserve the existing async `TaskManager::load()` API by delegating to the sync loader.

Closes #32

## Test Plan
- `cargo test -p codirigent-core task_manager::tests::test_load_with_tasks --no-default-features`
- `git diff --check`

Additional check attempted:
- `cargo check -p codirigent-ui` currently fails on Linux before reaching this change because `codirigent-detector` only defines `NativeMonitor` / `find_file_opened_by_pid_impl` for macOS and Windows targets.
